### PR TITLE
feat: support eth_getBlockReceipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Mainly supported requests with determined block number. Other methods will be di
 - `eth_chainId`
 - `eth_getBalance`
 - `eth_getBlockByNumber`
+- `eth_getBlockReceipts`
 - `eth_getCode`
 - `eth_getStorageAt`
 - `eth_getTransactionByHash`

--- a/src/rpc_cache_handler/eth_get_block_receipts.rs
+++ b/src/rpc_cache_handler/eth_get_block_receipts.rs
@@ -1,0 +1,25 @@
+use anyhow::Context;
+use serde_json::Value;
+
+use crate::rpc_cache_handler::RpcCacheHandler;
+
+#[derive(Default, Clone)]
+pub struct EthGetBlockReceipts;
+
+impl RpcCacheHandler for EthGetBlockReceipts {
+    fn method_name(&self) -> &'static str {
+        "eth_getBlockReceipts"
+    }
+
+    fn extract_cache_key(&self, params: &Value) -> anyhow::Result<Option<String>> {
+        let params = params
+            .as_array()
+            .context("params not found or not an array")?;
+
+        let block_number = params[0].as_str().context("params[0] not a string")?;
+        let block_number =
+            u64::from_str_radix(&block_number[2..], 16).context("block number not a hex string")?;
+
+            Ok(Some(format!("0x{:x}", block_number)))
+    }
+}

--- a/src/rpc_cache_handler/eth_get_block_receipts.rs
+++ b/src/rpc_cache_handler/eth_get_block_receipts.rs
@@ -20,6 +20,6 @@ impl RpcCacheHandler for EthGetBlockReceipts {
         let block_number =
             u64::from_str_radix(&block_number[2..], 16).context("block number not a hex string")?;
 
-            Ok(Some(format!("0x{:x}", block_number)))
+        Ok(Some(format!("0x{:x}", block_number)))
     }
 }

--- a/src/rpc_cache_handler/mod.rs
+++ b/src/rpc_cache_handler/mod.rs
@@ -5,6 +5,7 @@ pub use eth_call::EthCall;
 pub use eth_chainid::EthChainId;
 pub use eth_get_balance::EthGetBalance;
 pub use eth_get_block_by_number::EthGetBlockByNumber;
+pub use eth_get_block_receipts::EthGetBlockReceipts;
 pub use eth_get_code::EthGetCode;
 pub use eth_get_storage_at::EthGetStorageAt;
 pub use eth_get_transaction_by_block_hash_and_index::EthGetTransactionByBlockHashAndIndex;
@@ -18,6 +19,7 @@ mod eth_call;
 mod eth_chainid;
 mod eth_get_balance;
 mod eth_get_block_by_number;
+mod eth_get_block_receipts;
 mod eth_get_code;
 mod eth_get_storage_at;
 mod eth_get_transaction_by_block_hash_and_index;
@@ -44,6 +46,7 @@ pub fn all_factories() -> Vec<RpcCacheHandlerFactory> {
         || Box::new(EthChainId) as Box<dyn RpcCacheHandler>,
         || Box::new(EthGetBalance) as Box<dyn RpcCacheHandler>,
         || Box::new(EthGetBlockByNumber) as Box<dyn RpcCacheHandler>,
+        || Box::new(EthGetBlockReceipts) as Box<dyn RpcCacheHandler>,
         || Box::new(EthGetCode) as Box<dyn RpcCacheHandler>,
         || Box::new(EthGetStorageAt) as Box<dyn RpcCacheHandler>,
         || Box::new(EthGetTransactionByBlockHashAndIndex) as Box<dyn RpcCacheHandler>,


### PR DESCRIPTION
feat: support eth_getBlockReceipts

test
```shell
curl -X POST  'http://127.0.0.1:8124/eth-chain' -d '{"jsonrpc":"2.0","method":"eth_getBlockReceipts","params":["0x12329f1"],"id":1}' -H 'Content-Type: application/json'
```

backend logs:

```shell
[2024-01-25T06:47:18Z INFO  cached_eth_rpc] cache missed for method eth_getBlockReceipts with key 1:eth_getBlockReceipts:0x12329f1
[2024-01-25T06:47:46Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 1:eth_getBlockReceipts:0x12329f1
[2024-01-25T06:47:48Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 1:eth_getBlockReceipts:0x12329f1
[2024-01-25T06:47:49Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 1:eth_getBlockReceipts:0x12329f1
[2024-01-25T06:47:50Z INFO  cached_eth_rpc] cache hit for method eth_getBlockReceipts with key 1:eth_getBlockReceipts:0x12329f1
```


